### PR TITLE
Fix getting committer count for projects and repos

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,12 @@
     "vscode": {
       "extensions": [
         "mechatroner.rainbow-csv",
-        "shakram02.bash-beautify"
+        "shakram02.bash-beautify",
+        "GitHub.copilot",
+        "GitHub.vscode-pull-request-github",
+        "GitHub.copilot-chat",
+        "github.vscode-github-actions",
+        "bierner.markdown-preview-github-styles"
       ]
     }
   }  

--- a/active_commiters.sh
+++ b/active_commiters.sh
@@ -141,7 +141,7 @@ elif [ "$CHOICE" = "Project" ]; then
         ACTIVE_COMMITTERS=$(curl -u :$PAT -X GET \
         -s \
         -H "Accept: application/json" \
-        "https://advsec.dev.azure.com/$ORG_NAME/_apis/management/meterUsageEstimate?api-version=7.2-preview.1&projectIds=$PROJECT_ID" | jq '.count')
+        "https://advsec.dev.azure.com/$ORG_NAME/$PROJECT_ID/_apis/management/meterUsageEstimate?api-version=7.2-preview.1" | jq '.count')
 
         echo "$PROJECT_ID, $PROJECT_NAME, $ACTIVE_COMMITTERS" >> $TEMP_FOLDER/projects_active_committers.csv
     done
@@ -170,7 +170,7 @@ else
         # ACTIVE_COMMITTERS=$(curl -u :$PAT -X GET \
         # -s \
         # -H "Accept: application/json" \
-        # "https://advsec.dev.azure.com/$ORG_NAME/_apis/management/meterUsageEstimate?api-version=7.2-preview.1&projectIds=$PROJECT_ID" | jq '.count')
+        # "https://advsec.dev.azure.com/$ORG_NAME/$PROJECT_ID/_apis/management/meterUsageEstimate?api-version=7.2-preview.1 | jq '.count')
 
         echo "$PROJECT_ID, $PROJECT_NAME" >> $TEMP_FOLDER/projects.csv
     done
@@ -209,7 +209,7 @@ else
         ACTIVE_COMMITTERS=$(curl -u :$PAT -X GET \
         -s \
         -H "Accept: application/json" \
-        "https://advsec.dev.azure.com/$ORG_NAME/_apis/management/meterUsageEstimate?api-version=7.2-preview.1&projectIds=$PROJECT_ID&repositoryIds=$REPO_ID" | jq '.count')
+        "https://advsec.dev.azure.com/$ORG_NAME/$PROJECT_ID/_apis/management/repositories/$REPO_ID/meterUsageEstimate?api-version=7.2-preview.1" | jq '.count')
 
         echo "$REPO_ID, $REPO_NAME, $ACTIVE_COMMITTERS" >> "$TEMP_FOLDER/${PROJECT_ID}_active_committers_by_repo.csv"
     done


### PR DESCRIPTION
This pull request includes changes to the `active_commiters.sh` script. The changes modify the URL used in the curl command in three different sections of the script. These modifications seem to change the way the script interacts with the Azure DevOps API to get the count of active committers.

Changes to API interaction:

* [`active_commiters.sh`](diffhunk://#diff-9fa2134ffc25a9fe14bc9fc93c39de919474683eb3caa29bfc1aba0a1be608a7L144-R144): Modified the URL used in the curl command in the `elif [ "$CHOICE" = "Project" ]` section to directly include the `$PROJECT_ID` in the URL instead of as a query parameter.
* [`active_commiters.sh`](diffhunk://#diff-9fa2134ffc25a9fe14bc9fc93c39de919474683eb3caa29bfc1aba0a1be608a7L173-R173): Similar modification was made in the commented curl command in the `else` section.
* [`active_commiters.sh`](diffhunk://#diff-9fa2134ffc25a9fe14bc9fc93c39de919474683eb3caa29bfc1aba0a1be608a7L212-R212): In another `else` section, the URL was changed to include both `$PROJECT_ID` and `$REPO_ID` directly in the URL instead of as query parameters.