### PR TITLE
Fix sed command

### DIFF
--- a/active_commiters.sh
+++ b/active_commiters.sh
@@ -123,7 +123,11 @@ function validatePAT() {
         validatePAT
     fi
 
-    sed -i '' "s/^PAT=.*/PAT=${PAT}/" .env
+    SEDOPTION="-i"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        SEDOPTION="-i ''"
+    fi
+    sed $SEDOPTION "s/^PAT=.*/PAT=${PAT}/" .env
 }
 
 function showTitle() {
@@ -336,7 +340,11 @@ while true; do
         ORG_NAME=$(gum input --header="Enter your Azure DevOps Organization Name" )
 
         # Replace the organization name in the config file
-        sed -i '' "s/^ORG_NAME=.*/ORG_NAME=${ORG_NAME}/" .env
+        SEDOPTION="-i"
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            SEDOPTION="-i ''"
+        fi
+        sed $SEDOPTION "s/^ORG_NAME=.*/ORG_NAME=${ORG_NAME}/" .env
 
         validatePAT
 

--- a/active_commiters.sh
+++ b/active_commiters.sh
@@ -77,7 +77,7 @@ function check_if_required_variables_are_set() {
         echo "PAT=$PAT" > .env
         echo "ORG_NAME=$ORG_NAME" >> .env
 
- 	validatePAT
+        validatePAT
     fi
 
 }

--- a/active_commiters.sh
+++ b/active_commiters.sh
@@ -73,11 +73,11 @@ function check_if_required_variables_are_set() {
         ORG_NAME=$(gum input --header="Enter your Azure DevOps Organization Name" )
         PAT=$(gum input --header="Enter your Personal Access Token" --password)    
 
-        validatePAT
-
         # Save the info in an .env file
         echo "PAT=$PAT" > .env
         echo "ORG_NAME=$ORG_NAME" >> .env
+
+ 	validatePAT
     fi
 
 }


### PR DESCRIPTION
The `sed` command fails for me using both the dev container and running the script on WSL2/Ubuntu. I also get an error if the .env file does not exist before the `validatePAT` call. This PR attempts to fix both of these issues.

Note: This has not been verified on macOS.